### PR TITLE
Update build script to overwrite AMDVLK and get tag message from local repository

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,7 @@
 <manifest>
 
   <remote  name="vulkan-github"
-           fetch="." />
+           fetch="https://github.com/GPUOpen-Drivers" />
 
   <default revision="master"
            remote="vulkan-github"

--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,7 @@
 <manifest>
 
   <remote  name="vulkan-github"
-           fetch="https://github.com/GPUOpen-Drivers" />
+           fetch="." />
 
   <default revision="master"
            remote="vulkan-github"

--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,6 @@
   <project path="drivers/pal" name="pal" revision="ae55b19b7553bf204b4945de9c11c5b05bc0e167"/>
   <project path="drivers/llpc" name="llpc" revision="7857f2e209fc65374f2891be52e3a4a22fbae483"/>
   <project path="drivers/gpurt" name="gpurt" revision="b89f22aadd0a335be632055434a7f8ba152fcb37"/>
-  <project path="drivers/AMDVLK" name="AMDVLK" revision="refs/tags/v-2022.Q3.5"/>
   <project path="drivers/llvm-project" name="llvm-project" revision="5c82ef808fd269c95f5bd166d1846149e3afadc2"/>
   <project path="drivers/third_party/metrohash" name="MetroHash" revision="18893fb28601bb9af1154cd1a671a121fff6d8d3"/>
   <project path="drivers/third_party/cwpack" name="CWPack" revision="4f8cf0584442a91d829d269158567d7ed926f026"/>


### PR DESCRIPTION
1. Remove the amdvlk repo info from the manifest.
2. Sync a fresh amdvlk repo every time to avoid tag conflict by end-users.