### PR TITLE
Fetch git submodules

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -7,7 +7,8 @@
   <default revision="master"
            remote="vulkan-github"
            sync-j="8"
-           sync-c="true" />
+           sync-c="true"
+           sync-s="true" />
 
   <project path="drivers/xgl" name="xgl" revision="dev"/>
   <project path="drivers/pal" name="pal" revision="dev"/>


### PR DESCRIPTION
The "sync-s" option tells repo to also fetch any submodules that any of the projects may have. This will allow us to fetch llvm-dialects as a submodule of LLPC.

See: https://github.com/GPUOpen-Drivers/llpc/pull/2023